### PR TITLE
Add build phase to script - @talum

### DIFF
--- a/script.js
+++ b/script.js
@@ -155,6 +155,59 @@ async function main () {
   }
 }
 
+/*
+ * ==============================================================
+ *                         BUILD
+ * ==============================================================
+ */
+
+const TEMP_HTML_PATH = path.join(tempDir, inputFilenameNoExt + '_temp.htm')
+
+async function build (filepath) {
+  var shortFileName = filepath.replace(inputDir, '')
+  if ((path.basename(filepath) = 'config.yml') || (filepath.endsWith('.plugin.js')))
+    await updateConfig()
+    return
+  }
+  var page = relaxedGlobals.puppeteerPage
+  // Ignore the call if ReLaXed is already busy processing other files.
+
+  if (!(relaxedGlobals.watchedExtensions.some(ext => filepath.endsWith(ext)))) {
+    if (!(['.pdf', '.htm'].some(ext => filepath.endsWith(ext)))) {
+      console.log(colors.grey(`No process defined for file ${shortFileName}.`))
+    }
+    return
+  }
+
+  if (relaxedGlobals.busy) {
+    console.log(colors.grey(`File ${shortFileName}: ignoring trigger, too busy.`))
+    return
+  }
+
+  console.log(colors.magenta.bold(`\nProcessing ${shortFileName}...`))
+  relaxedGlobals.busy = true
+  var t0 = performance.now()
+
+
+  var taskPromise = null
+
+  for (var watcher of relaxedGlobals.pluginHooks.watchers) {
+    if (watcher.instance.extensions.some(ext => filepath.endsWith(ext))) {
+      taskPromise = watcher.instance.handler(filepath, page)
+      break
+    }
+  }
+
+  if (!taskPromise) {
+    taskPromise = masterToPDF(inputPath, relaxedGlobals, TEMP_HTML_PATH, outputPath, locals)
+  }
+  await taskPromise
+  var duration = ((performance.now() - t0) / 1000).toFixed(2)
+  console.log(colors.magenta.bold(`... Done in ${duration}s`))
+  relaxedGlobals.busy = false
+}
+
+
 /**
  * Watch `watchLocations` paths for changes and continuously rebuild
  *

--- a/script.js
+++ b/script.js
@@ -199,7 +199,7 @@ async function build (filepath) {
   }
 
   if (!taskPromise) {
-    taskPromise = masterToPDF(inputPath, relaxedGlobals, TEMP_HTML_PATH, outputPath, locals)
+    taskPromise = masterToPDF(inputPath, relaxedGlobals, tempHtmlPath, outputPath, locals)
   }
   await taskPromise
   var duration = ((performance.now() - t0) / 1000).toFixed(2)

--- a/script.js
+++ b/script.js
@@ -161,7 +161,7 @@ async function main () {
  * ==============================================================
  */
 
-const TEMP_HTML_PATH = path.join(tempDir, inputFilenameNoExt + '_temp.htm')
+const tempHtmlPath = path.join(tempDir, inputFilenameNoExt + '_temp.htm')
 
 async function build (filepath) {
   var shortFileName = filepath.replace(inputDir, '')


### PR DESCRIPTION
This PR adds a build phase to the script.

---

There are a few things that are either wrong or could be improved: 

1. On lines 164 and 202, `TEMP_HTML_PATH` should be camelCased like the other constants in the file 
2. On line 168, the accidental assignment `=` should actually be a comparison `===`
3. Also on line 168, the opening conditional bracket `{` is missing 

Suggest the appropriate changes.